### PR TITLE
Add: kubewall to the list

### DIFF
--- a/data/repos
+++ b/data/repos
@@ -183,6 +183,7 @@ https://github.com/hashicorp/packer
 https://github.com/haxsaw/hikaru
 https://github.com/hcavarsan/kftray
 https://github.com/headlamp-k8s/headlamp
+https://github.com/kubewall/kubewall
 https://github.com/helm-unittest/helm-unittest
 https://github.com/helm/helm
 https://github.com/helmfile/helmfile


### PR DESCRIPTION
Add: kubewall to the list
https://github.com/kubewall/kubewall
A single binary kubernetes dashboard to manage your multiple clusters.

