### PR TITLE
feat: add kubestellar/console to curated tools list

### DIFF
--- a/data/repos
+++ b/data/repos
@@ -308,6 +308,7 @@ https://github.com/kubeshop/monokle
 https://github.com/kubeshop/tracetest
 https://github.com/kubesphere/kubesphere
 https://github.com/KubeStellar/kubeflex
+https://github.com/kubestellar/console
 https://github.com/kubestellar/kubestellar
 https://github.com/kubetail-org/kubetail
 https://github.com/kubetoolsca/krs


### PR DESCRIPTION
## What

Adds `kubestellar/console` to the data/repos list for inclusion in the auto-generated curated tool listing.

## Why

KubeStellar Console is a CNCF Sandbox project — an AI-powered multi-cluster Kubernetes dashboard with:

- Multi-cluster management across edge, cloud, and hybrid environments
- AI/LLM-powered operations
- Real-time observability and CNCF project integrations (Argo, Kyverno, Istio, 20+ more)
- GitHub: https://github.com/kubestellar/console