### PR TITLE
Add ingero-io/ingero - eBPF GPU causal observability for Kubernetes

### DIFF
--- a/data/repos
+++ b/data/repos
@@ -199,6 +199,7 @@ https://github.com/ibm/kone
 https://github.com/identiops/terraform-hcloud-k3s
 https://github.com/Infisical/infisical
 https://github.com/infracost/infracost
+https://github.com/ingero-io/ingero
 https://github.com/inguardians/peirates
 https://github.com/inovex/illuminatio # 💀 Archived
 https://github.com/instrumenta/kubeval # 💀 Deprecated (use kubeconform)


### PR DESCRIPTION
Adds ingero-io/ingero to `data/repos`.

Open-source eBPF agent for GPU causal observability. Helm chart deploys as a DaemonSet on Kubernetes; traces CUDA APIs and host kernel events (sched, off-CPU, blkio, TCP) to explain GPU latency on K8s nodes.

Same form factor as Cilium / Pixie / Kubeshark (already in the list), focused on GPU workloads.

- One binary, <2% overhead, Apache 2.0 + GPL-2.0.
- Repo: https://github.com/ingero-io/ingero
- Helm chart: https://github.com/ingero-io/ingero/tree/main/deploy/helm