### PR TITLE
Add Klustr (native Kubernetes desktop client)

### DIFF
--- a/data/repos
+++ b/data/repos
@@ -447,6 +447,7 @@ https://github.com/rtvkiz/minimal
 https://github.com/runfinch/finch
 https://github.com/ruoshan/autoportforward
 https://github.com/ryane/kfilt
+https://github.com/SametKUM/klustr
 https://github.com/scality/metalk8s
 https://github.com/scholzj/terraform-aws-kubernetes
 https://github.com/score-spec/spec


### PR DESCRIPTION
Adds **[Klustr](https://github.com/SametKUM/klustr)** to `data/repos` (alphabetically sorted, before `scality/metalk8s`).

A native (non-Electron, Wails/Go + React) cross-platform Kubernetes desktop client. Pure client — **nothing is installed in the cluster**; it drives the standard Kubernetes API straight from the user's `~/.kube/config`. Multi-context aggregated views, live informer-backed resources (no polling), logs, exec, port-forwarding, full RBAC, plus first-class CRD, Helm v3, Argo CD, Flux CD and Gateway API support built in.

Meets the contribution requirements:
- **Open source with a clear license** — MIT.
- **Actively maintained** — frequent commits and tagged releases.
- **Kubernetes-related** — a dedicated Kubernetes client.
- **Stable** — ships release binaries (macOS + Linux), Homebrew cask and AUR package.