### PR TITLE
Add InfraCanvas

### DIFF
--- a/data/repos
+++ b/data/repos
@@ -53,6 +53,7 @@ https://github.com/bridgecrewio/checkov
 https://github.com/brigadecore/brigade
 https://github.com/buildpacks-community/kpack
 https://github.com/buildpacks/pack
+https://github.com/bytestrix/InfraCanvas
 https://github.com/caldito/soup
 https://github.com/canonical/lxd
 https://github.com/canonical/microk8s


### PR DESCRIPTION
Adds [InfraCanvas](https://github.com/bytestrix/InfraCanvas) — live Docker & Kubernetes infrastructure visualization: containers, pods, volumes and networks as one interactive topology map, with built-in terminals, logs and actions. Single self-hosted binary, AGPL-3.0.